### PR TITLE
fix updates after the second one

### DIFF
--- a/lib/component/protos.js
+++ b/lib/component/protos.js
@@ -14,6 +14,7 @@ var equal = require('jkroso/equals');
  */
 
 exports.setState = function(state, done){
+  this._pendingState = this._pendingState || {};
   assign(this._pendingState, state);
   this.emit('change', done);
 };

--- a/lib/renderer/component.js
+++ b/lib/renderer/component.js
@@ -147,6 +147,8 @@ ComponentRenderer.prototype.update = function(force){
 
   // when we're done updating.
   function done() {
+    // reset the lifecycle state.
+    self.lifecycleState = null;
     self.emit('flush');
   }
 
@@ -168,7 +170,7 @@ ComponentRenderer.prototype.update = function(force){
   // merge in the changes.
   var previousState = this.state;
   var previousProps = this.props;
-  this.state = assign(this.state, this.instance._pendingState);
+  this.state = assign({}, this.state, this.instance._pendingState);
   this.props = this._pendingProps || this.props;
 
   // reset.
@@ -184,9 +186,6 @@ ComponentRenderer.prototype.update = function(force){
 
   // unset previous so we don't keep it in memory.
   this.previous = null;
-
-  // reset the lifecycle state.
-  this.lifecycleState = null;
 
   // post-update.
   this.trigger('afterUpdate', [

--- a/lib/renderer/diff.js
+++ b/lib/renderer/diff.js
@@ -81,7 +81,9 @@ exports.diffChildren = function(previous, current, el){
     // the node has been removed.
     if (right == null) {
       this.removeComponents(left);
-      el.removeChild(el.childNodes[j]);
+      if ('component' != left.type) {
+        el.removeChild(el.childNodes[j]);
+      }
       j = j - 1;
       continue;
     }


### PR DESCRIPTION
@anthonyshort this fixes the issue where properties are blank between renders, so on update after the first time, the prev === next props, which was always blank.
