### PR TITLE
Allow hooks to return a promise to update state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ default: index.js
 #
 
 build.js: node_modules $(js)
-	@browserify test/index.js -t babelify > build.js
+	@browserify -d -e test/index.js -t [ babelify --optional es7.asyncFunctions ] > build.js
 
 tests.js: node_modules $(js)
-	@browserify test/index.js -t babelify | bfc > tests.js
+	@browserify -d -e test/index.js -t [ babelify --optional es7.asyncFunctions ] | bfc > tests.js
 
 index.js: node_modules $(js)
 	@browserify -s deku lib/index.js | bfc > index.js

--- a/README.md
+++ b/README.md
@@ -284,6 +284,42 @@ function render (component) {
 
 At the moment we only support the `key` attribute on components for simplicity. Things become slightly more hairy when moving elements around within components. So far we haven't ran into a case where this has been a major problem.
 
+## Experimental: ES7 async functions
+
+The purpose of most lifecycle hooks is usually to update the state, either by inspecting the DOM or fetching some external resources. We can simplify the concept of the lifecycle hooks by making the pure using ES7 async functions.
+
+```js
+async function afterMount ({ props }, el) {
+  var items = await request(props.url)
+  var projects = await Projects.getAll()
+
+  // Return an object to update state
+  return { 
+    items: items,
+    projects: projects,
+    loaded: true
+  }
+}
+```
+
+Instead of using the `updateState` function we can just return an object that will be merged in with the current state. We can do this because the lifecycle hooks are able to return a promise that resolves into a state change. All you need to do is return a promise and resolve it with an object. 
+
+We could do this with standard promises too:
+
+```js
+function afterMount ({ props }, el) {
+  return request(props.url)
+    .then(Projects.getAll)
+    .then(function(items, projects){
+      return {
+        items: items,
+        projects: projects,
+        loaded: true
+      }
+    })
+}
+```
+
 ## Tests
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/deku.svg)](https://saucelabs.com/u/deku)

--- a/lib/render.js
+++ b/lib/render.js
@@ -16,6 +16,7 @@ var defaults = utils.defaults
 var forEach = require('fast.js/forEach')
 var assign = require('fast.js/object/assign')
 var reduce = require('fast.js/reduce')
+var isPromise = require('is-promise')
 
 /**
  * All of the events can bind to
@@ -262,7 +263,7 @@ function render (app, container, opts) {
 
   function setState (entity) {
     return function (nextState) {
-      updateEntityState(entity, nextState)
+      updateEntityStateAsync(entity, nextState)
     }
   }
 
@@ -1029,10 +1030,25 @@ function render (app, container, opts) {
     var update = setState(entity)
     args.push(update)
     var result = trigger(name, entity, args)
-    if (result && typeof result.then === 'function') {
-      result.then(function(newState){
-        update(newState)
+    if (result) {
+      updateEntityStateAsync(entity, result)
+    }
+  }
+
+  /**
+   * Update the entity state using a promise
+   *
+   * @param {Entity} entity
+   * @param {Promise} promise
+   */
+
+  function updateEntityStateAsync (entity, value) {
+    if (isPromise(value)) {
+      value.then(function (newState) {
+        updateEntityState(entity, newState)
       })
+    } else {
+      updateEntityState(entity, value)
     }
   }
 
@@ -1223,10 +1239,8 @@ function render (app, container, opts) {
       if (entity) {
         var update = setState(entity)
         var result = fn.call(null, e, entity.context, update)
-        if (result && typeof result.then === 'function') {
-          result.then(function(newState){
-            update(newState)
-          })
+        if (result) {
+          updateEntityStateAsync(entity, result)
         }
       } else {
         fn.call(null, e)

--- a/lib/render.js
+++ b/lib/render.js
@@ -343,7 +343,7 @@ function render (app, container, opts) {
     while (entityId = mountQueue.pop()) {
       var entity = entities[entityId]
       trigger('afterRender', entity, [entity.context, entity.nativeElement])
-      trigger('afterMount', entity, [entity.context, entity.nativeElement, setState(entity)])
+      triggerUpdate('afterMount', entity, [entity.context, entity.nativeElement, setState(entity)])
     }
   }
 
@@ -401,7 +401,7 @@ function render (app, container, opts) {
     trigger('afterRender', entity, [entity.context, entity.nativeElement])
 
     // trigger afterUpdate after all children have updated.
-    trigger('afterUpdate', entity, [entity.context, previousProps, previousState, setState(entity)])
+    triggerUpdate('afterUpdate', entity, [entity.context, previousProps, previousState])
   }
 
   /**
@@ -1011,7 +1011,29 @@ function render (app, container, opts) {
 
   function trigger (name, entity, args) {
     if (typeof entity.component[name] !== 'function') return
-    entity.component[name].apply(null, args)
+    return entity.component[name].apply(null, args)
+  }
+
+  /**
+   * Trigger a hook on the component and allow state to be
+   * updated too.
+   *
+   * @param {String} name
+   * @param {Object} entity
+   * @param {Array} args
+   *
+   * @return {void}
+   */
+
+  function triggerUpdate (name, entity, args) {
+    var update = setState(entity)
+    args.push(update)
+    var result = trigger(name, entity, args)
+    if (result && typeof result.then === 'function') {
+      result.then(function(newState){
+        update(newState)
+      })
+    }
   }
 
   /**
@@ -1199,7 +1221,13 @@ function render (app, container, opts) {
     keypath.set(handlers, [entityId, path, eventType], throttle(function (e) {
       var entity = entities[entityId]
       if (entity) {
-        fn.call(null, e, entity.context, setState(entity))
+        var update = setState(entity)
+        var result = fn.call(null, e, entity.context, update)
+        if (result && typeof result.then === 'function') {
+          result.then(function(newState){
+            update(newState)
+          })
+        }
       } else {
         fn.call(null, e)
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bump": "git://github.com/ianstormtaylor/bump.git#0.4.2",
     "component-classes": "^1.2.3",
     "duo-test": "^0.3.13",
+    "es6-promise": "^2.1.1",
     "memoizee": "^0.3.8",
     "minify": "^1.4.11",
     "mochify": "^2.1.1",
@@ -30,6 +31,7 @@
     "fast.js": "^0.1.1",
     "get-uid": "^1.0.1",
     "is-dom": "^1.0.5",
+    "is-promise": "^2.0.0",
     "object-path": "^0.8.1",
     "per-frame": "^3.0.0",
     "sliced": "0.0.5"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Create view components using a virtual DOM",
   "main": "lib/index.js",
   "devDependencies": {
-    "babelify": "^5.0.4",
+    "babelify": "^6.1.1",
     "benchmark": "^1.0.0",
     "bfc": "~0.3.1",
     "browserify": "^8.1.1",

--- a/test/dom/hooks.js
+++ b/test/dom/hooks.js
@@ -163,3 +163,32 @@ it('should fire mount events top-down', function () {
     'child:afterMount'
   ])
 });
+
+
+it('should return a promise from afterMount to update state', function (done) {
+  var Test = {
+    initialState () {
+      return { text: 'foo' }
+    },
+    render ({ state }) {
+      return <div>{state.text}</div>
+    },
+    afterMount (component, el) {
+      return new Promise(function(resolve){
+        setTimeout(function(){
+          resolve({ text: 'hello world' })
+        }, 10)
+      })
+    },
+    afterUpdate () {
+      assert.equal(container.innerHTML, '<div>hello world</div>')
+      document.body.removeChild(container)
+      renderer.remove()
+      done()
+    }
+  }
+  var container = document.createElement('div')
+  document.body.appendChild(container)
+  var renderer = render(deku(<Test />), container, { batching: false })
+  assert.equal(container.innerHTML, '<div>foo</div>')
+});

--- a/test/dom/hooks.js
+++ b/test/dom/hooks.js
@@ -165,23 +165,33 @@ it('should fire mount events top-down', function () {
 });
 
 
-it('should return a promise from afterMount to update state', function (done) {
+it.only('should return a promise from afterMount to update state', function (done) {
+  var fetch = function(){
+    return new Promise(function(resolve){
+      setTimeout(function(){
+        resolve('two')
+      }, 10)
+    })
+  }
+
   var Test = {
     initialState () {
-      return { text: 'foo' }
+      return {
+        text: 'one',
+        id: 'one'
+      }
     },
     render ({ state }) {
-      return <div>{state.text}</div>
+      return <div id={state.id}>{state.text}</div>
     },
-    afterMount (component, el) {
-      return new Promise(function(resolve){
-        setTimeout(function(){
-          resolve({ text: 'hello world' })
-        }, 10)
-      })
+    afterMount: async function (component, el) {
+      var text = await fetch()
+      return {
+        text: text
+      }
     },
     afterUpdate () {
-      assert.equal(container.innerHTML, '<div>hello world</div>')
+      assert.equal(container.innerHTML, '<div id="one">two</div>')
       document.body.removeChild(container)
       renderer.remove()
       done()
@@ -190,5 +200,5 @@ it('should return a promise from afterMount to update state', function (done) {
   var container = document.createElement('div')
   document.body.appendChild(container)
   var renderer = render(deku(<Test />), container, { batching: false })
-  assert.equal(container.innerHTML, '<div>foo</div>')
+  assert.equal(container.innerHTML, '<div id="one">one</div>')
 });

--- a/test/dom/hooks.js
+++ b/test/dom/hooks.js
@@ -165,7 +165,7 @@ it('should fire mount events top-down', function () {
 });
 
 
-it.only('should return a promise from afterMount to update state', function (done) {
+it('should return a promise from afterMount to update state', function (done) {
   var fetch = function(){
     return new Promise(function(resolve){
       setTimeout(function(){

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 require('es6-promise').polyfill()
+require("babelify/polyfill")
 
 describe('virtual', function(){
   require('./virtual')

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
+require('es6-promise').polyfill()
 
 describe('virtual', function(){
   require('./virtual')


### PR DESCRIPTION
I don't think this is just right yet, but it allows hooks/handlers to return a promise to update state instead of using `setState` as a function. It allows these hooks to be pure functions. Behind the scenes the resolved value of the promise is used to call `setState`, so the promise needs to resolve to an object.

```
function afterUpdate (component, prevProps, prevState) {
  return request(components.props.url, function (data) {
    return data.items
  })
}

function onClick(e, component) {
  return doSomeAsycThing(e.target.value)
}
```

Not entirely sure of the benefit yet other than returning a value feels cleaner. 

It doesn't work for `render`, because you might need to pass a callback down to a child component to update your own state later. 

This is all backwards compatible and `setState` is still given to all of the functions as the last param.