### PR TITLE
adding support for checked/disabled properties

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -843,7 +843,6 @@ function render (app, container, opts) {
       case 'checked':
       case 'disabled':
       case 'selected':
-        console.log('add', el, name, value);
         el[name] = true
         el.setAttribute(name, name)
         break
@@ -881,7 +880,6 @@ function render (app, container, opts) {
       case 'defaultChecked':
       case 'disabled':
       case 'selected':
-        console.log('remove', el, name);
         el[name] = false;
         el.removeAttribute(name)
         break
@@ -1090,7 +1088,7 @@ function render (app, container, opts) {
     sources.forEach(function (source) {
       connections[source] = connections[source] || []
       connections[source].push(update)
-      
+
       function update (data) {
         var prop = map[source]
         for (var entityId in entities) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -843,6 +843,7 @@ function render (app, container, opts) {
       case 'checked':
       case 'disabled':
       case 'selected':
+        console.log('add', el, name, value);
         el[name] = true
         el.setAttribute(name, name)
         break
@@ -880,6 +881,7 @@ function render (app, container, opts) {
       case 'defaultChecked':
       case 'disabled':
       case 'selected':
+        console.log('remove', el, name);
         el[name] = false;
         el.removeAttribute(name)
         break

--- a/lib/render.js
+++ b/lib/render.js
@@ -844,10 +844,7 @@ function render (app, container, opts) {
       case 'disabled':
       case 'selected':
         el[name] = true
-        el.setAttribute(name, name)
         break
-      case 'defaultChecked':
-      case 'defaultValue':
       case 'innerHTML':
       case 'value':
         el[name] = value
@@ -874,19 +871,15 @@ function render (app, container, opts) {
       removeEvent(entityId, path, events[name])
       return
     }
-
     switch (name) {
       case 'checked':
-      case 'defaultChecked':
       case 'disabled':
       case 'selected':
-        el[name] = false;
-        el.removeAttribute(name)
+        el[name] = false
         break
-      case 'defaultValue':
       case 'innerHTML':
       case 'value':
-        el[name] = ''
+        el[name] = ""
         break
       default:
         el.removeAttribute(name)

--- a/lib/render.js
+++ b/lib/render.js
@@ -842,6 +842,7 @@ function render (app, container, opts) {
     switch (name) {
       case 'checked':
       case 'disabled':
+      case 'selected':
         el[name] = true
         el.setAttribute(name, name)
         break
@@ -877,6 +878,7 @@ function render (app, container, opts) {
     switch (name) {
       case 'checked':
       case 'disabled':
+      case 'selected':
         el[name] = false;
         el.removeAttribute(name)
         break

--- a/lib/render.js
+++ b/lib/render.js
@@ -846,11 +846,11 @@ function render (app, container, opts) {
         el[name] = true
         el.setAttribute(name, name)
         break
-      case 'value':
-        el.value = value
-        break
+      case 'defaultChecked':
+      case 'defaultValue':
       case 'innerHTML':
-        el.innerHTML = value
+      case 'value':
+        el[name] = value
         break
       case svg.isAttribute(name):
         el.setAttributeNS(svg.namespace, name, value)
@@ -877,10 +877,16 @@ function render (app, container, opts) {
 
     switch (name) {
       case 'checked':
+      case 'defaultChecked':
       case 'disabled':
       case 'selected':
         el[name] = false;
         el.removeAttribute(name)
+        break
+      case 'defaultValue':
+      case 'innerHTML':
+      case 'value':
+        el[name] = ''
         break
       default:
         el.removeAttribute(name)

--- a/lib/render.js
+++ b/lib/render.js
@@ -840,6 +840,11 @@ function render (app, container, opts) {
       return
     }
     switch (name) {
+      case 'checked':
+      case 'disabled':
+        el[name] = true
+        el.setAttribute(name, name)
+        break
       case 'value':
         el.value = value
         break
@@ -868,7 +873,17 @@ function render (app, container, opts) {
       removeEvent(entityId, path, events[name])
       return
     }
-    el.removeAttribute(name)
+
+    switch (name) {
+      case 'checked':
+      case 'disabled':
+        el[name] = false;
+        el.removeAttribute(name)
+        break
+      default:
+        el.removeAttribute(name)
+        break
+    }
   }
 
   /**

--- a/test/dom/attributes.js
+++ b/test/dom/attributes.js
@@ -155,12 +155,12 @@ it('should render a selected option properly', function () {
 
   mount(app, function (el) {
     var options = el.querySelectorAll('option');
-
     selected(options[0])
     unselected(options[1]);
 
     // should now be enabled
     app.mount(<Select selected={1} />);
+    options = el.querySelectorAll('option');
     unselected(options[0]);
     selected(options[1]);
   })

--- a/test/dom/attributes.js
+++ b/test/dom/attributes.js
@@ -163,3 +163,51 @@ it('should render a selected option properly', function () {
     assert(!option.hasAttribute('selected'));
   })
 })
+
+it('should render a defaultValue input properly', function () {
+  var Input = {
+    render: function ({ props }) {
+      return dom('input', { defaultValue: props.defaultValue });
+    }
+  }
+
+  var app = deku();
+  app.mount(<Input defaultValue='hello world' />);
+
+  mount(app, function (el) {
+    var input = el.querySelector('input');
+
+    // initially should be disabled
+    assert.equal(input.defaultValue, 'hello world');
+    assert(!input.hasAttribute('defaultValue'));
+
+    // should now be enabled
+    app.mount(<Input defaultValue={false} />);
+    assert(!input.defaultValue);
+    assert(!input.hasAttribute('defaultValue'));
+  })
+})
+
+it('should render a defaultChecked checkbox properly', function () {
+  var Input = {
+    render: function ({ props }) {
+      return dom('input', { type: 'checkbox', defaultChecked: props.defaultChecked });
+    }
+  }
+
+  var app = deku();
+  app.mount(<Input defaultChecked={true} />);
+
+  mount(app, function (el) {
+    var input = el.querySelector('input');
+
+    // initially should be disabled
+    assert(input.defaultChecked);
+    assert(!input.hasAttribute('defaultChecked'));
+
+    // should now be enabled
+    app.mount(<Input defaultChecked={false} />);
+    assert(!input.defaultChecked);
+    assert(!input.hasAttribute('defaultChecked'));
+  })
+})

--- a/test/dom/attributes.js
+++ b/test/dom/attributes.js
@@ -86,8 +86,56 @@ it('should render and update innerHTML', function () {
   app.mount(<Test content="Hello <strong>deku</strong>" />)
 
   mount(app, function(el){
-    assert.equal(el.innerHTML,'<div>Hello <strong>deku</strong></div>');
+    assert.equal(el.innerHTML,'<div>Hello <strong>deku</strong></div>')
     app.mount(<Test content="Hello <strong>Pluto</strong>" />)
-    assert.equal(el.innerHTML,'<div>Hello <strong>Pluto</strong></div>');
+    assert.equal(el.innerHTML,'<div>Hello <strong>Pluto</strong></div>')
+  })
+})
+
+it('should render a checked checkbox properly', function () {
+  var Input = {
+    render: function ({ props }) {
+      return dom('input', { type: 'checkbox', checked: props.checked })
+    }
+  }
+
+  var app = deku();
+  app.mount(<Input checked={true} />);
+
+  mount(app, function (el) {
+    var checkbox = el.querySelector('input');
+
+    // initially should be checked
+    assert(checkbox.checked)
+    assert.equal(checkbox.getAttribute('checked'), 'checked');
+
+    // should now be unchecked
+    app.mount(<Input checked={false} />);
+    assert(!checkbox.checked);
+    assert(!checkbox.hasAttribute('checked'));
+  })
+})
+
+it('should render a disabled input properly', function () {
+  var Input = {
+    render: function ({ props }) {
+      return dom('input', { disabled: props.disabled });
+    }
+  }
+
+  var app = deku();
+  app.mount(<Input disabled={true} />);
+
+  mount(app, function (el) {
+    var checkbox = el.querySelector('input');
+
+    // initially should be disabled
+    assert(checkbox.disabled);
+    assert.equal(checkbox.getAttribute('disabled'), 'disabled');
+
+    // should now be enabled
+    app.mount(<Input disabled={false} />);
+    assert(!checkbox.disabled);
+    assert(!checkbox.hasAttribute('disabled'));
   })
 })

--- a/test/dom/attributes.js
+++ b/test/dom/attributes.js
@@ -141,14 +141,16 @@ it('should render a disabled input properly', function () {
 })
 
 it('should render a selected option properly', function () {
-  var Option = {
+  var Select = {
     render: function ({ props }) {
-      return dom('option', { selected: props.selected });
+      return dom('select', [
+        dom('option', { selected: props.selected })
+      ]);
     }
   }
 
   var app = deku();
-  app.mount(<Option selected={true} />);
+  app.mount(<Select selected={true} />);
 
   mount(app, function (el) {
     var option = el.querySelector('option');
@@ -158,7 +160,7 @@ it('should render a selected option properly', function () {
     assert.equal(option.getAttribute('selected'), 'selected');
 
     // should now be enabled
-    app.mount(<Option selected={false} />);
+    app.mount(<Select selected={false} />);
     assert(!option.selected);
     assert(!option.hasAttribute('selected'));
   })

--- a/test/dom/attributes.js
+++ b/test/dom/attributes.js
@@ -56,20 +56,13 @@ it('should not touch the DOM just because attributes are falsy', function () {
   })
 })
 
-it('should update the real value of input fields', function () {
-  var Input = {
-    render: function(component){
-      let {props, state} = component
-      return dom('input', { value: props.value })
-    }
-  };
-
+it('should update the value of input fields', function () {
   var app = deku()
-  app.mount(<Input value="Bob" />);
+  app.mount(<input value="Bob" />);
 
   mount(app, function(el){
     assert.equal(el.querySelector('input').value, 'Bob');
-    app.mount(<Input value="Tom" />);
+    app.mount(<input value="Tom" />);
     assert.equal(el.querySelector('input').value, 'Tom');
   })
 })
@@ -92,66 +85,68 @@ it('should render and update innerHTML', function () {
   })
 })
 
-it('should render a checked checkbox properly', function () {
-  var Input = {
-    render: function ({ props }) {
-      return dom('input', { type: 'checkbox', checked: props.checked })
-    }
-  }
-
+it('should render and update the checked state of a checkbox', function () {
   var app = deku();
-  app.mount(<Input checked={true} />);
+  app.mount(<input checked={true} />);
 
   mount(app, function (el) {
     var checkbox = el.querySelector('input');
 
     // initially should be checked
     assert(checkbox.checked)
-    assert.equal(checkbox.getAttribute('checked'), 'checked');
+    assert.equal(checkbox.getAttribute('checked'), null);
 
     // should now be unchecked
-    app.mount(<Input checked={false} />);
+    app.mount(<input checked={false} />);
     assert(!checkbox.checked);
     assert(!checkbox.hasAttribute('checked'));
   })
 })
 
-it('should render a disabled input properly', function () {
-  var Input = {
-    render: function ({ props }) {
-      return dom('input', { disabled: props.disabled });
-    }
-  }
-
+it('should render and update a disabled input', function () {
   var app = deku();
-  app.mount(<Input disabled={true} />);
+  app.mount(<input disabled={true} />);
 
   mount(app, function (el) {
     var checkbox = el.querySelector('input');
 
     // initially should be disabled
     assert(checkbox.disabled);
-    assert.equal(checkbox.getAttribute('disabled'), 'disabled');
+    assert.equal(checkbox.hasAttribute('disabled'), true);
 
     // should now be enabled
-    app.mount(<Input disabled={false} />);
-    assert(!checkbox.disabled);
-    assert(!checkbox.hasAttribute('disabled'));
+    app.mount(<input disabled={false} />);
+    assert.equal(checkbox.disabled, false);
+    assert.equal(checkbox.hasAttribute('disabled'), false);
   })
 })
 
-it('should render a selected option properly', function () {
-  var Select = {
-    render: function ({ props }) {
-      return dom('select', [
-        dom('option', { selected: props.selected === 0 }),
-        dom('option', { selected: props.selected === 1 })
-      ]);
-    }
-  }
-
+it('should render a disabled input as a boolean', function () {
   var app = deku();
-  app.mount(<Select selected={0} />);
+  app.mount(<input disabled />);
+
+  mount(app, function (el) {
+    var checkbox = el.querySelector('input');
+
+    // initially should be disabled
+    assert(checkbox.disabled);
+    assert.equal(checkbox.hasAttribute('disabled'), true);
+
+    // should now be enabled
+    app.mount(<input />);
+    assert.equal(checkbox.disabled, false);
+    assert.equal(checkbox.hasAttribute('disabled'), false);
+  })
+})
+
+it('should render and update a selected option', function () {
+  var app = deku();
+  app.mount(
+    <select>
+      <option selected>one</option>
+      <option>two</option>
+    </select>
+  );
 
   mount(app, function (el) {
     var options = el.querySelectorAll('option');
@@ -159,7 +154,13 @@ it('should render a selected option properly', function () {
     unselected(options[1]);
 
     // should now be enabled
-    app.mount(<Select selected={1} />);
+    app.mount(
+      <select>
+        <option>one</option>
+        <option selected>two</option>
+      </select>
+    );
+
     options = el.querySelectorAll('option');
     unselected(options[0]);
     selected(options[1]);
@@ -167,59 +168,9 @@ it('should render a selected option properly', function () {
 
   function selected(option) {
     assert(option.selected, 'selected DOM property should be true');
-    assert.equal(option.getAttribute('selected'), 'selected');
   }
 
   function unselected(option) {
     assert(!option.selected, 'selected DOM property should be false');
-    assert(!option.hasAttribute('selected'));
   }
-})
-
-it('should render a defaultValue input properly', function () {
-  var Input = {
-    render: function ({ props }) {
-      return dom('input', { defaultValue: props.defaultValue });
-    }
-  }
-
-  var app = deku();
-  app.mount(<Input defaultValue='hello world' />);
-
-  mount(app, function (el) {
-    var input = el.querySelector('input');
-
-    // initially should be disabled
-    assert.equal(input.defaultValue, 'hello world');
-    assert(!input.hasAttribute('defaultValue'));
-
-    // should now be enabled
-    app.mount(<Input defaultValue={false} />);
-    assert(!input.defaultValue);
-    assert(!input.hasAttribute('defaultValue'));
-  })
-})
-
-it('should render a defaultChecked checkbox properly', function () {
-  var Input = {
-    render: function ({ props }) {
-      return dom('input', { type: 'checkbox', defaultChecked: props.defaultChecked });
-    }
-  }
-
-  var app = deku();
-  app.mount(<Input defaultChecked={true} />);
-
-  mount(app, function (el) {
-    var input = el.querySelector('input');
-
-    // initially should be disabled
-    assert(input.defaultChecked);
-    assert(!input.hasAttribute('defaultChecked'));
-
-    // should now be enabled
-    app.mount(<Input defaultChecked={false} />);
-    assert(!input.defaultChecked);
-    assert(!input.hasAttribute('defaultChecked'));
-  })
 })

--- a/test/dom/attributes.js
+++ b/test/dom/attributes.js
@@ -139,3 +139,27 @@ it('should render a disabled input properly', function () {
     assert(!checkbox.hasAttribute('disabled'));
   })
 })
+
+it('should render a selected option properly', function () {
+  var Option = {
+    render: function ({ props }) {
+      return dom('option', { selected: props.selected });
+    }
+  }
+
+  var app = deku();
+  app.mount(<Option selected={true} />);
+
+  mount(app, function (el) {
+    var option = el.querySelector('option');
+
+    // initially should be disabled
+    assert(option.selected);
+    assert.equal(option.getAttribute('selected'), 'selected');
+
+    // should now be enabled
+    app.mount(<Option selected={false} />);
+    assert(!option.selected);
+    assert(!option.hasAttribute('selected'));
+  })
+})

--- a/test/dom/attributes.js
+++ b/test/dom/attributes.js
@@ -144,26 +144,36 @@ it('should render a selected option properly', function () {
   var Select = {
     render: function ({ props }) {
       return dom('select', [
-        dom('option', { selected: props.selected })
+        dom('option', { selected: props.selected === 0 }),
+        dom('option', { selected: props.selected === 1 })
       ]);
     }
   }
 
   var app = deku();
-  app.mount(<Select selected={true} />);
+  app.mount(<Select selected={0} />);
 
   mount(app, function (el) {
-    var option = el.querySelector('option');
+    var options = el.querySelectorAll('option');
 
-    // initially should be disabled
-    assert(option.selected);
-    assert.equal(option.getAttribute('selected'), 'selected');
+    selected(options[0])
+    unselected(options[1]);
 
     // should now be enabled
-    app.mount(<Select selected={false} />);
-    assert(!option.selected);
-    assert(!option.hasAttribute('selected'));
+    app.mount(<Select selected={1} />);
+    unselected(options[0]);
+    selected(options[1]);
   })
+
+  function selected(option) {
+    assert(option.selected, 'selected DOM property should be true');
+    assert.equal(option.getAttribute('selected'), 'selected');
+  }
+
+  function unselected(option) {
+    assert(!option.selected, 'selected DOM property should be false');
+    assert(!option.hasAttribute('selected'));
+  }
 })
 
 it('should render a defaultValue input properly', function () {


### PR DESCRIPTION
@anthonyshort this addresses dekujs/todomvc#1 by having the attributes `checked` and `disabled` set both the HTML attribute as well as the DOM property.

I'm sure there are other similar DOM properties, but this is a great start. (includes tests of course)