### PR TITLE
Always empty the container element

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -104,8 +104,7 @@ function render (app, container, opts) {
   var options = defaults(assign({}, app.options || {}, opts || {}), {
     pooling: true,
     batching: true,
-    validateProps: false,
-    emptyContainer: false
+    validateProps: false
   })
 
   /**
@@ -303,7 +302,7 @@ function render (app, container, opts) {
     if (!currentNativeElement) {
       currentElement = app.element
       currentNativeElement = toNative(rootId, '0', currentElement)
-      if (options.emptyContainer) removeAllChildren(container);
+      removeAllChildren(container);
       container.appendChild(currentNativeElement)
     } else if (currentElement !== app.element) {
       currentNativeElement = patch(rootId, currentElement, app.element, currentNativeElement)

--- a/lib/render.js
+++ b/lib/render.js
@@ -302,6 +302,10 @@ function render (app, container, opts) {
     if (!currentNativeElement) {
       currentElement = app.element
       currentNativeElement = toNative(rootId, '0', currentElement)
+      if (container.children.length > 1) {
+        console.warn('Deku is about to destroy some potentially useful elements, since it empties the container before rendering.');
+        if (container === document.body) console.warn('Using document.body is allowed, but you should consider using a dedicated container element for your app.');
+      }
       removeAllChildren(container);
       container.appendChild(currentNativeElement)
     } else if (currentElement !== app.element) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -104,7 +104,8 @@ function render (app, container, opts) {
   var options = defaults(assign({}, app.options || {}, opts || {}), {
     pooling: true,
     batching: true,
-    validateProps: false
+    validateProps: false,
+    emptyContainer: false
   })
 
   /**
@@ -302,6 +303,7 @@ function render (app, container, opts) {
     if (!currentNativeElement) {
       currentElement = app.element
       currentNativeElement = toNative(rootId, '0', currentElement)
+      if (options.emptyContainer) removeAllChildren(container);
       container.appendChild(currentNativeElement)
     } else if (currentElement !== app.element) {
       currentNativeElement = patch(rootId, currentElement, app.element, currentNativeElement)

--- a/test/dom/index.js
+++ b/test/dom/index.js
@@ -403,5 +403,5 @@ it('should empty the container before initial render', function () {
 
   var app = deku(<Component />);
   render(app, el, { emptyContainer: true });
-  assert.equal(el.innerText, 'b');
+  assert.equal(el.innerHTML, 'b');
 })

--- a/test/dom/index.js
+++ b/test/dom/index.js
@@ -403,5 +403,5 @@ it('should empty the container before initial render', function () {
 
   var app = deku(<Component />);
   render(app, el, { emptyContainer: true });
-  assert.equal(el.innerHTML, 'b');
+  assert.equal(el.innerText || el.textContent, 'b');
 })

--- a/test/dom/index.js
+++ b/test/dom/index.js
@@ -390,3 +390,18 @@ describe('memoization', function () {
   });
 
 })
+
+it('should empty the container before initial render', function () {
+  var Component = {
+    render: function () {
+      return dom('div', [ 'b' ]);
+    }
+  };
+
+  var el = div();
+  el.innerHTML = 'a';
+
+  var app = deku(<Component />);
+  render(app, el, { emptyContainer: true });
+  assert.equal(el.innerText, 'b');
+})

--- a/test/dom/index.js
+++ b/test/dom/index.js
@@ -399,9 +399,10 @@ it('should empty the container before initial render', function () {
   };
 
   var el = div();
-  el.innerHTML = 'a';
+  el.innerHTML = '<div>a</div>';
 
   var app = deku(<Component />);
-  render(app, el, { emptyContainer: true });
-  assert.equal(el.innerText || el.textContent, 'b');
+  var renderer = render(app, el);
+  assert.equal(el.innerHTML, '<div>b</div>');
+  renderer.remove()
 })


### PR DESCRIPTION
This will fix #120 by always emptying the container before render. We've also added some warning messages if:

 - the container has more than 1 element already present (since it could be destroying something useful)
 - the container is `document.body`, since it's usually better to use a dedicated container element

/cc @anthonyshort 