### PR TITLE
fix swapping components with shared source

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -85,6 +85,7 @@ function render (app, container, opts) {
   var currentElement
   var currentNativeElement
   var connections = {}
+  var components = {}
   var entities = {}
   var pools = {}
   var handlers = {}
@@ -224,6 +225,9 @@ function render (app, container, opts) {
     trigger('beforeUnmount', entity, [entity.context, entity.nativeElement])
     unmountChildren(entityId)
     removeAllEvents(entityId)
+    var componentEntities = components[entityId].entities;
+    delete componentEntities[entityId]
+    delete components[entityId]
     delete entities[entityId]
     delete children[entityId]
   }
@@ -1068,6 +1072,8 @@ function render (app, container, opts) {
     var entities = component.entities = component.entities || {}
     // add entity to component list
     entities[entity.id] = entity
+    // map to component so you can remove later.
+    components[entity.id] = component;
 
     // get 'class-level' sources.
     var sources = component.sources

--- a/test/dom/sources.js
+++ b/test/dom/sources.js
@@ -33,3 +33,52 @@ it('should set source without property type', function(done){
     done();
   });
 });
+
+it('should handle removing entities', function(done){
+  const App = {
+    propTypes: {
+      foo: { source: 'foo' }
+    },
+
+    render(component) {
+      let {props} = component;
+      let {foo} = props;
+      let page = foo ? <Page2/> : <Page1/>
+
+      return <div>{page}</div>
+    }
+  }
+
+  const Page1 = {
+    propTypes: {
+      foo: { source: 'foo' }
+    },
+
+    render(component) {
+      return <div class="Page1">Page1</div>
+    }
+  }
+
+  const Page2 = {
+    propTypes: {
+      foo: { source: 'foo' }
+    },
+
+    render(component) {
+      return <div class="Page2">Page2</div>
+    }
+  }
+
+  var el = document.createElement('div');
+  var app = deku(<App/>);
+  render(app, el);
+  app.set('foo', 'bar');
+  requestAnimationFrame(function(){
+    assert.equal(el.innerHTML, '<div><div class="Page2">Page2</div></div>');
+    app.set('foo', false);
+    requestAnimationFrame(function(){
+      assert.equal(el.innerHTML, '<div><div class="Page1">Page1</div></div>');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
cc @stevenmiller888 @anthonyshort this demos/fixes an issue with sources, where old entity refs needed to be removed when a component with sources is removed, and later another component source updates.