### PR TITLE
 Replaced fast.js require with modular requirement.

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -10,13 +10,12 @@ var uid = require('get-uid')
 var throttle = require('per-frame')
 var keypath = require('object-path')
 var type = require('component-type')
-var fast = require('fast.js')
 var utils = require('./utils')
 var svg = require('./svg')
 var defaults = utils.defaults
-var forEach = fast.forEach
-var assign = fast.assign
-var reduce = fast.reduce
+var forEach = require('fast.js/forEach')
+var assign = require('fast.js/object/assign')
+var reduce = require('fast.js/reduce')
 
 /**
  * All of the events can bind to

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,5 +1,4 @@
-var fast = require('fast.js')
-var indexOf = fast.indexOf
+var indexOf = require('fast.js/array/indexOf')
 
 /**
  * This file lists the supported SVG elements used by the


### PR DESCRIPTION
Before, `deku` loaded the entire `fast.js` library, significantly increasing build size. With this more specific require-approach, the build size is reduced. Though I haven’t checked the accurate size diff, it is ~69 KB less.