### PR TITLE
Validate nested property types

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -1222,32 +1222,52 @@ function render (app, container, opts) {
    * optional: Boolean
    */
 
-  function validateProps (props, rules) {
+  function validateProps (props, rules, optPrefix) {
+    var prefix = optPrefix || ''
     if (!options.validateProps) return
-
-    // TODO: Only validate in dev mode
     forEach(rules, function (options, name) {
-      if (name === 'children') return
-      var value = props[name]
+      if (!options) {
+        throw new Error('deku: propTypes should have an options object for each type')
+      }
+
+      var propName = prefix ? prefix + '.' + name : name
+      var value = keypath.get(props, name)
+      var valueType = type(value)
+      var typeFormat = type(options.type)
       var optional = (options.optional === true)
+
+      // If it's optional and doesn't exist
       if (optional && value == null) {
         return
       }
+
+      // If it's required and doesn't exist
       if (!optional && value == null) {
-        throw new Error('Missing prop named: ' + name)
+        throw new TypeError('Missing property: ' + propName)
       }
-      if (options.type && type(value) !== options.type) {
-        throw new Error('Invalid type for prop named: ' + name)
+
+      // It's a nested type
+      if (typeFormat === 'object') {
+        validateProps(value, options.type, propName)
+        return
       }
+
+      // If it's the incorrect type
+      if (typeFormat === 'string' && valueType !== options.type) {
+        throw new TypeError('Invalid property type: ' + propName)
+      }
+
+      // If it's an invalid value
       if (options.expects && options.expects.indexOf(value) < 0) {
-        throw new Error('Invalid value for prop named: ' + name + '. Must be one of ' + options.expects.toString())
+        throw new TypeError('Invalid property value: ' + propName)
       }
     })
 
     // Now check for props that haven't been defined
     forEach(props, function (value, key) {
+      // props.children is always passed in, even if it's not defined
       if (key === 'children') return
-      if (!rules[key]) throw new Error('Unexpected prop named: ' + key)
+      if (!rules[key]) throw new Error('Unexpected property: ' + key)
     })
   }
 

--- a/test/dom/validate.js
+++ b/test/dom/validate.js
@@ -23,7 +23,7 @@ describe('validation', function () {
     app.mount(<Component />);
 
     mount(app, null, function(e){
-      assert.equal(e.message, 'Missing prop named: text');
+      assert.equal(e.message, 'Missing property: text');
       done();
     })
   })
@@ -41,7 +41,7 @@ describe('validation', function () {
     app.mount(<Component text={true} />);
 
     mount(app, null, function(e){
-      assert.equal(e.message, 'Invalid type for prop named: text');
+      assert.equal(e.message, 'Invalid property type: text');
       done();
     })
   })
@@ -57,7 +57,7 @@ describe('validation', function () {
     app.option('validateProps', true)
     app.mount(<Component text="raz" />);
     mount(app, null, function(e){
-      assert.equal(e.message, 'Invalid value for prop named: text. Must be one of foo,bar,baz');
+      assert.equal(e.message, 'Invalid property value: text');
       done();
     })
   });
@@ -96,7 +96,7 @@ describe('validation', function () {
       .option('validateProps', true)
       .mount(<Component text="foo" />);
     mount(app, null, function(e){
-      assert.equal(e.message, 'Unexpected prop named: text');
+      assert.equal(e.message, 'Unexpected property: text');
       done();
     })
   })
@@ -108,6 +108,63 @@ describe('validation', function () {
     var app = deku()
       .option('validateProps', false)
       .mount(<Component text="foo" />);
+    mount(app)
+  });
+
+  it('should validate nested types', function (done) {
+    var Component = {
+      render: div,
+      propTypes: {
+        'data': {
+          type: {
+            'text': { type: 'string' }
+          }
+        }
+      }
+    }
+    var app = deku()
+    app.option('validateProps', true)
+    app.mount(<Component data={{ text: true }} />);
+    mount(app, null, function(e){
+      assert.equal(e.message, 'Invalid property type: data.text');
+      done();
+    })
+  });
+
+  it('should validate missing nested types', function (done) {
+    var Component = {
+      render: div,
+      propTypes: {
+        'data': {
+          type: {
+            'text': { type: 'string' }
+          }
+        }
+      }
+    }
+    var app = deku()
+    app.option('validateProps', true)
+    app.mount(<Component />);
+    mount(app, null, function(e){
+      assert.equal(e.message, 'Missing property: data');
+      done();
+    })
+  });
+
+  it('should allow optional nested types', function () {
+    var Component = {
+      render: div,
+      propTypes: {
+        'data': {
+          type: {
+            'text': { type: 'string', optional: true }
+          }
+        }
+      }
+    }
+    var app = deku()
+    app.option('validateProps', true)
+    app.mount(<Component data={{}} />);
     mount(app)
   });
 


### PR DESCRIPTION
Fixes #139.

Allows validating of nested property types. 

```js

let propTypes = {
  'data': {
    type: {
      'text': { type: 'string' }
    }
  }
}
```

```js
let data = {
  text: 'Hello World'
}
```