### PR TITLE
add `action` hook on components

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -1147,8 +1147,6 @@ function render (app, container, opts) {
 
     // initialize sources once for a component type.
     registerSources(entity)
-    // call external register hook.
-    if (component.register) component.register(app)
     component.registered = true
   }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -1141,18 +1141,46 @@ function render (app, container, opts) {
    */
 
   function register (entity) {
+    registerEntity(entity)
+    var component = entity.component
+    if (component.registered) return
+
+    // initialize sources once for a component type.
+    registerSources(entity)
+    // call external register hook.
+    if (component.register) component.register(app)
+    component.registered = true
+  }
+
+  /**
+   * Add entity to data-structures related to components/entities.
+   *
+   * @param {Entity} entity
+   */
+
+  function registerEntity(entity) {
     var component = entity.component
     // all entities for this component type.
     var entities = component.entities = component.entities || {}
     // add entity to component list
     entities[entity.id] = entity
     // map to component so you can remove later.
-    components[entity.id] = component;
+    components[entity.id] = component
+  }
 
+  /**
+   * Initialize sources for a component by type.
+   *
+   * @param {Entity} entity
+   */
+
+  function registerSources(entity) {
+    var component = components[entity.id]
     // get 'class-level' sources.
     // if we've already hooked it up, then we're good.
     var sources = component.sources
     if (sources) return
+    var entities = component.entities
 
     // hook up sources.
     var map = component.sourceToPropertyName = {}
@@ -1181,9 +1209,6 @@ function render (app, container, opts) {
         }
       }
     })
-
-    // hook up actions
-    if (component.action) component.action(app)
   }
 
   /**

--- a/lib/render.js
+++ b/lib/render.js
@@ -1150,9 +1150,11 @@ function render (app, container, opts) {
     components[entity.id] = component;
 
     // get 'class-level' sources.
+    // if we've already hooked it up, then we're good.
     var sources = component.sources
     if (sources) return
 
+    // hook up sources.
     var map = component.sourceToPropertyName = {}
     component.sources = sources = []
     var propTypes = component.propTypes
@@ -1179,6 +1181,9 @@ function render (app, container, opts) {
         }
       }
     })
+
+    // hook up actions
+    if (component.action) component.action(app)
   }
 
   /**

--- a/test/dom/register.js
+++ b/test/dom/register.js
@@ -1,0 +1,85 @@
+/** @jsx dom */
+
+import {mount,div} from '../helpers'
+import {component,render,deku,dom} from '../../'
+import trigger from 'trigger-event'
+import raf from 'component-raf'
+import assert from 'assert'
+
+it('should call register hook', function(done){
+  const App = {
+    propTypes: {
+      closeOverlay: { source: 'currentCloseHandler' },
+      popup: { source: 'currentPopup' }
+    },
+
+    render({props}) {
+      let {closeOverlay, popup} = props
+
+      return (
+        <div class='App' onClick={closeOverlay}>
+          <Page/>
+          {popup}
+        </div>
+      )
+    }
+  }
+
+  const Page = {
+    propTypes: {
+      openPopup: { source: 'openPopup' }
+    },
+
+    render({props}) {
+      var openPopup = props.openPopup
+
+      return (
+        <div class='Page'>
+          <button class='Page-popupButton' onClick={onClick}>Open Popup!</button>
+        </div>
+      )
+
+      function onClick() {
+        openPopup(<Popup>Some stuff</Popup>)
+      }
+    }
+  }
+
+  const Popup = {
+    register(app) {
+      app.set('openPopup', function(node){
+        app.set('currentCloseHandler', close)
+        app.set('currentPopup', node)
+
+        function close() {
+          app.set('currentPopup', null)
+        }
+      })
+    },
+
+    render({props}) {
+      let {children} = props
+      return <div class='Popup'>
+        {children}
+      </div>
+    }
+  }
+
+  var el = document.createElement('div')
+  var app = deku(<App/>)
+  app.use(Popup.register)
+  render(app, el)
+  raf(function(){
+    document.body.appendChild(el)
+    trigger(el.querySelector('.Page-popupButton'), 'click')
+    raf(function(){
+      assert(el.querySelector('.Popup'))
+      trigger(el.querySelector('.App'), 'click')
+      raf(function(){
+        assert(!el.querySelector('.Popup'))
+        document.body.removeChild(el)
+        done()
+      })
+    })
+  })
+})

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,7 @@ describe('DOM Renderer', function(){
   require('./dom/hooks')
   require('./dom/svg')
   require('./dom/sources')
+  require('./dom/register')
 })
 
 describe('String Renderer', function(){


### PR DESCRIPTION
After trying all sorts of ways of doing local-to-global sorta stuff (tooltips, dialogs, popups, etc.), there seems to be a simple way to handle it, wanted to share.

## Problem

It's a pain in both Deku and React to handle popups, dialogs, modals, and stuff like that, where you _invoke_ or _create_ one of those components globally from some deeply nested position.

### Background

The typical solution is to just use a jQuery plugin or twitter-bootstrap wrapper which deals directly with the native DOM. Other pure-virtual-dom solutions use all kinds of hardcore workarounds to get it to work, but the underlying implementation is pretty much always ridiculously complicated and hard to understand unless you wrote the code yourself.

## Experiment

This PR proposes a solution to that problem, making it very easy to have purely virtual-dom implementations of popups, dialogs, tooltips, etc. The next section demonstrates the basic module setup and API to make this happen.

Here are the components used to demonstrate:

```js
// app.jsx

export const propTypes = {
  closeOverlay: { source: 'currentCloseHandler' },
  popup: { source: 'currentPopup' }
}

export function render({props}) {
  let {closeOverlay, popup} = props

  return (
    <div class='App' onClick={closeOverlay}>
      <Page/>
    </div>
  )
}
```

```js
// page.jsx (some random component)

export const propTypes = {
  openPopup: { source: 'openPopup' }
}

export function render({props}) {
  let {openPopup} = props

  return (
    <div class='Page'>
      <button onClick={onClick}>Open Popup!</button>
    </div>
  )

  function onClick() {
    openPopup(<Popup>Some stuff</Popup>)
  }
}
```
```js
// popup.jsx (a custom popup component)

export function action(app) {
  app.set('openPopup', function(node){
    app.set('currentCloseHandler', close)
    app.set('currentPopup', node)

    function close() {
      app.set('currentPopup', null)
    }
  })
}

export function render({props}) {
  let {children} = props
  return <div class='Popup'>
    {children}
  </div>
}
```

And here is how you would instantiate the app, with the popup plugin:

```js
let app = tree(<App/>)
app.use(Popup.action)
render(app, document.body)
```

Notice the `app.use(Popup.action)`. This is the core of it. Basically, the popup can define a sort of "global api", which the app then uses (see app.js' `propTypes`, which gets the `currentPopup` and such).

This solves the problem of how to get a component like a popup (or dialog, tooltip, etc.) to be instantiated locally, but be positioned globally, _with global event handlers_.

Normally, when a popup is opened, you might add an `afterMount` hook and do `window.addEventListener('click', removeThePopup)`, but that is a code smell, the goal is not to have to deal with the low-level native dom rendering engine.

Notice that there are no places where the native dom is touched (to add handlers or anything). In addition, no hooks like `afterMount` are needed.

All of the above can be done without any core extensions.

## A simplification

This is a core feature though, since alerts and modals are featured in pretty much all apps (and alerts are even built into the browser). As such, it would simplify standard workflows if this was built in.

If we built this in, the API for creating an app would look like this:

```js
let app = tree(<App/>)
render(app, document.body)
```

Notice the _lack_ of needing to do `app.use(Popup.action)`. This PR makes all components that get used anywhere in the virtual dom get automatically wired up with the app. This means if you use an open source popup, you can just plug it into some part of your virtual dom and it will "just work" without having to also "initialize" it at the app level as a plugin. That could be done automatically.

All that needs to happen is two things:

1. Decide on the name of the function (currently called `action`, but could be called `plugin` or `hook` or something).
2. Hook it up in the [register function](https://github.com/dekujs/deku/blob/3353b7cc9f41d0ed7cf72308ec03f8b429f36ee6/lib/render.js#L1143).

This 1-line PR implements this feature, and will allow for this simplified setup.

## Conclusion

This simplifies handling global/local components, such as popups, dialogs, tooltips, etc.. This has always been a problem in React and Deku, which people workaround by either using native dom plugins (jquery plugins, twitter bootstrap, etc.), or by having super complicated and hard to understand virtual-dom logic.

This PR simplifies that common situation, and hopefully will start a conversation on how to build on top of this sort of thing with conventions that standardize the local/global communication.

Thoughts?