### PR TITLE
Fixed: State not committed during shouldUpdate

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -330,7 +330,10 @@ function render (app, container, opts) {
     var entity = entities[entityId]
     setSources(entity)
 
-    if (!shouldUpdate(entity)) return updateChildren(entityId)
+    if (!shouldUpdate(entity)) {
+      commit(entity)
+      return updateChildren(entityId)
+    }
 
     var currentTree = entity.virtualElement
     var nextProps = entity.pendingProps


### PR DESCRIPTION
If shouldUpdate returns `false` it should still commit the state change, but just not trigger a re-render.