### PR TITLE
Handle null element in isElement(). fixes #180

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -740,7 +740,7 @@ function render (app, container, opts) {
     } else {
 
       // Just remove the text node
-      if (!isElement(el)) return el.parentNode.removeChild(el)
+      if (!isElement(el)) return el && el.parentNode.removeChild(el)
 
       // Then we need to find any components within this
       // branch and unmount them.
@@ -924,7 +924,7 @@ function render (app, container, opts) {
    */
 
   function isElement (el) {
-    return !!el.tagName
+    return !!(el && el.tagName)
   }
 
   /**


### PR DESCRIPTION
Calling `isElement(null)` currently throws. Also updates `removeElement()` to only attempt to remove a text node if the element is not null. See #180 