### PR TITLE
Adding a `rootListenerNode` option to deku.

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -74,7 +74,7 @@ function render (app, container, opts) {
   /**
    * Listen to DOM events
    */
-
+  var rootElement = getRootElement(container)
   addNativeEventListeners()
 
   /**
@@ -1195,7 +1195,7 @@ function render (app, container, opts) {
 
   function addNativeEventListeners () {
     forEach(events, function (eventType) {
-      document.body.addEventListener(eventType, handleEvent, true)
+      rootElement.addEventListener(eventType, handleEvent, true)
     })
   }
 
@@ -1205,7 +1205,7 @@ function render (app, container, opts) {
 
   function removeNativeEventListeners () {
     forEach(events, function (eventType) {
-      document.body.removeEventListener(eventType, handleEvent, true)
+      rootElement.removeEventListener(eventType, handleEvent, true)
     })
   }
 
@@ -1431,4 +1431,28 @@ function getNodeAtPath(el, path) {
     el = el.childNodes[parts.pop()]
   }
   return el
+}
+
+/**
+ * Retrieve the nearest 'body' ancestor of the given element or else the root
+ * element of the document in which stands the given element.
+ *
+ * This is necessary if you want to attach the events handler to the correct
+ * element and be able to dispatch events in document fragments such as
+ * Shadow DOM.
+ *
+ * @param  {HTMLElement} el The element on which we will render an app.
+ * @return {HTMLElement}    The root element on which we will attach the events
+ *                          handler.
+ */
+function getRootElement(el) {
+  while (el.parentElement) {
+    if (el.tagName === 'BODY' || !el.parentElement) {
+      return el;
+    }
+
+    el = el.parentElement;
+  }
+
+  return el;
 }

--- a/test/dom/events.js
+++ b/test/dom/events.js
@@ -292,6 +292,31 @@ it('should remove handlers when an element is removed', function (done) {
   })
 })
 
+// Let's run this test only if the browser supports shadow DOM
+if (document.body.createShadowRoot)
+  it('should be possible to change the root listener node so we can render into document fragments', function(done) {
+    var Button = {
+      render: function(comp) {
+        return dom('button', {onClick: done.bind(null, null)});
+      }
+    };
+
+    var host = document.createElement('div');
+    var shadow = host.createShadowRoot();
+    shadow.innerHTML = '<div></div>';
+    var mountNode = shadow.querySelector('div');
+
+    document.body.appendChild(host);
+
+    var app = deku(<Button />)
+    var renderer = render(app, mountNode, { batching: false, rootListenerNode: shadow });
+    var button = shadow.querySelector('button');
+    trigger(button, 'click');
+
+    renderer.remove();
+    document.body.removeChild(host);
+  })
+
 it.skip('should keep focus on elements', function () {
   var App = {
     render: function(comp, next) {


### PR DESCRIPTION
Hello deku!
Just proposing the addition of a `rootListenerNode` option to deku's rendering so it becomes possible to render an app within document fragments such as Shadow DOM (currently events won't work since the root listener is set on `document.body`). (The use case is the creation of a JavaScript bookmarklet that injects a parasitic sidebar into the page's dom and uses Shadow DOM to preserve CSS encapsulation).

Two remarks:
* `rootListenerNode` is quite an ugly name. I am sure you have nicer ideas for a name.
* It could be possible to detect the parent document of the node used to render and not having to set an option but this requires to use tricky recursive heuristics and I guess an option is easier.