### PR TITLE
Possibility to pass `false` as well as `null` in component children

### DIFF
--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -94,7 +94,7 @@ function virtual (type, props, children) {
  */
 
 function normalize (acc, node) {
-  if (node == null) {
+  if (node == null || node === false) {
     return acc
   }
   if (typeof node === 'string' || typeof node === 'number') {


### PR DESCRIPTION
Proposition to support `false` as a child component (`null` is already supported) so the following pattern (working with React) can work in deku:

```jsx
const PropertyListItem = {
  render(component) {
    let {props, state} = component;
    let {title, advanced, results, selectors} = props.item;

    return (
      <li>
        <input type="text" value={title} />
        {advanced && <input type="text" value={selectors} />}
        <div class="stateBar">
          <span class="count">{results.length}</span>
        </div>
      </li>
    );
  }
};
```

I am unsure where I could put a unit test for that but I'll gladly add one as soon as you tell me where I should do it.

Sorry for the PR flood :-).