### PR TITLE
Enhancing the possibilities of the class attribute

### DIFF
--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -236,11 +236,20 @@ function parseClass (value) {
   }
 
   // ['foo', 'bar', 'baz']
+  // ['foo', {bar: true}, 'baz']
+  // ['foo', false, 'baz']
   if (type(value) === 'array') {
     if (value.length === 0) {
       return
     }
-    value = value.join(' ')
+    value = value
+      .map(function(v) {
+        return type(v) === 'object' ? parseClass(v) : v;
+      })
+      .filter(function(v) {
+        return v;
+      })
+      .join(' ')
   }
 
   return value

--- a/test/virtual/index.js
+++ b/test/virtual/index.js
@@ -33,10 +33,21 @@ it('should not render class from an empty array', function () {
   assert(node.attributes.class === undefined);
 });
 
+it('should set class from a compacted array', function() {
+  var node = dom('div', { class: ['foo', false, 'bar', undefined, 'baz'] });
+  assert(node.attributes.class === 'foo bar baz');
+})
+
 it('should set class from an object', function () {
   var names = { foo: true, bar: false, baz: true };
   var node = dom('div', { class: names });
   assert(node.attributes.class === 'foo baz');
+});
+
+it('should set class from a array of mixed objects and strings', function() {
+  var names = ['foo', {bar: true, bor: false}, 'baz', {biz: true}];
+  var node = dom('div', { class: names });
+  assert(node.attributes.class === 'foo bar baz biz')
 });
 
 it('should set the style attribute with an object', function () {


### PR DESCRIPTION
Proposition to enhance the possibilities of the `class` attribute of the virtual elements. This is inspired by the full possibilities of [this](https://www.npmjs.com/package/classnames) popular package.

You can now do the following:

```jsx
// Compact array (dropping falsey values)
<div class={['foo', false, 'baz']} />

// Array of mixed strings and objects
<div class={['foo', {bar: true}, 'baz']} />
```

I've used a succession of `map`, `filter` and `join` in the code. Whether you'd accept the idea, just tell me whether you want me to low-level this for perfs.

Sorry for the PR flood again :-).