### PR TITLE
added ability to cancel events

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -1225,8 +1225,7 @@ function render (app, container, opts) {
       var fn = keypath.get(handlers, [target.__entity__, target.__path__, eventType])
       if (fn) {
         event.delegateTarget = target
-        fn(event)
-        break
+        if (false === fn(event)) break
       }
       target = target.parentNode
     }
@@ -1249,8 +1248,9 @@ function render (app, container, opts) {
         if (result) {
           updateEntityStateAsync(entity, result)
         }
+        return result
       } else {
-        fn.call(null, e)
+        return fn.call(null, e)
       }
     })
   }


### PR DESCRIPTION
cc @anthonyshort This makes it so you can cancel events. The use case is this:

```html
<div class='App' onClick={closePopup}>
  <div class='Item' onClick={openModal}>
    <div class='Item-settings' onClick={openPopup}>
    </div>
  </div>
</div>
```

If you click `Item-settings`, imagine it opens a popup. Then if you click anywhere _except_ the opened popup, it closes the popup. However, if you click on the `Item`, it both closes the popup and opens some modal window let's say. That's at least how it seems like it should work.

What _shouldn't_ happen are the following:

1. If you click `Item-settings` when everything is closed, it both opens the popup _and_ opens the modal.
2. If the popup is open, and you click `Item` outside of `Item-settings`, it leaves the popup open and also opens the modal.

The current implementation of Deku has the problem of (2). The reason is because it exits on the first found event handler in the tree.

https://github.com/dekujs/deku/blob/master/lib/render.js#L1229

This means that if the popup is open, and you click `Item`, then the `App` handler never gets executed (so the popup never gets closed).

So first try was removing `break`. But that causes problem (1): when you click `Item-settings` when nothing is open, it will both open the popup and the modal, because the event is handled by all handlers. So to fix this, I added:

```js
if (false === fn(event)) break;
```

This makes it so you can return `false` in an event handler, and it will stop propagation. I tried using `event.stopPropagation()` or `event.stopImmediatePropagation()` but there's [no indication that they have been called](http://stackoverflow.com/questions/7259753/in-a-javascript-event-how-to-determine-stoppropagation-has-been-called) (they are natively handled, which sucks here). So a common workaround is to `return false`. This is similar to how `array.forEach` works when you want to cancel, and I feel like I've seen this many times in event handling systems in the past.

This PR solves the problem of allowing you to have nested virtual elements handle the same event in a controllable way.

_Time spent figuring out: 2 hours_