### PR TITLE
Update element import in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ So now we can start defining components in their own module and export them. Let
 
 ```js
 // button.js
-import {element} from 'virtual-element'
+import element from 'virtual-element'
 
 let MyButton = {
   render ({props}) {

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -19,7 +19,8 @@ To use this in our app, we would just import it and mount it:
 
 ```js
 import {Button} from './button.js'
-import {element,tree,render} from 'deku'
+import {tree,render} from 'deku'
+import element from 'virtual-element'
 
 let app = tree(
   <Button>Hello!</Button>

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -17,7 +17,8 @@ browserify -t babelify main.js > build.js
 ## Duo
 
 ```
-import {element,tree,render} from 'segmentio/deku@0.2.1'
+import {tree,render} from 'dekujs/deku@0.5.0'
+import element from 'dekujs/virtual-element@1.1.1'
 ```
 
 With Duo you can just import directly from Github, then build it:

--- a/docs/guides/jsx.md
+++ b/docs/guides/jsx.md
@@ -33,7 +33,7 @@ The easiest way is to add it to your `.babelrc` file:
 Then make sure you import the `element` function:
 
 ```js
-import {element} from 'deku'
+import element from 'virtual-element'
 
 export function render (component) {
   let {props, state, id} = component;
@@ -47,7 +47,7 @@ You can also add a comment to the top of your files that tells babel which funct
 
 ```js
 /** @jsx element */
-import {element} from 'deku'
+import element from 'virtual-element'
 
 export function render (component) {
   let {props, state, id} = component;


### PR DESCRIPTION
With v0.5.0, `virtual-element` is used instead of `deku` for the
`import` and it exports a function so it shouldn't be destructured on
`import`. This commit updates a few places where either `deku` was
still being `import`ed or `element` was being destructured, or both.