### PR TITLE
Move internal component data off of components

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -33,11 +33,13 @@ module.exports = render
 function render (app, container, opts) {
   var frameId
   var isRendering
+  var internalId = '__dekuId__'
   var rootId = 'root'
   var currentElement
   var currentNativeElement
   var connections = {}
   var components = {}
+  var componentData = {}
   var entities = {}
   var handlers = {}
   var mountQueue = []
@@ -175,7 +177,7 @@ function render (app, container, opts) {
     trigger('beforeUnmount', entity, [entity.context, entity.nativeElement])
     unmountChildren(entityId)
     removeAllEvents(entityId)
-    var componentEntities = components[entityId].entities;
+    var componentEntities = getComponentEntities(components[entityId])
     delete componentEntities[entityId]
     delete components[entityId]
     delete entities[entityId]
@@ -1030,6 +1032,82 @@ function render (app, container, opts) {
   }
 
   /**
+  * Indicates whether a component has been registered
+  *
+  * @param {Component} component
+  *
+  * @return {Boolean}
+  */
+
+  function isRegistered (component) {
+    return component[internalId] in componentData
+  }
+
+  /**
+  * Adds an internal id to a component. This id is shared across
+  * all app instances and facilitates storing internal component
+  * data per app.
+  *
+  * @param {Component} component
+  */
+
+  function idComponent (component) {
+    Object.defineProperty(component, internalId, { value: uid() })
+  }
+
+  /**
+  * Gets the internal data of a component.
+  *
+  * @param {Component} component
+  *
+  * @return {Object}
+  */
+
+  function getComponentData (component) {
+    return componentData[component[internalId]]
+  }
+
+  /**
+  * Gets all of the entities of a particular component type.
+  *
+  * @param {Component} component
+  *
+  * @return {Object}
+  */
+
+  function getComponentEntities (component) {
+    return getComponentData(component).entities
+  }
+
+  /**
+  * Gets all of the sources of a particular component type.
+  *
+  * @param {Component} component
+  *
+  * @return {Array}
+  */
+
+  function getComponentSources (component) {
+    return getComponentData(component).sources
+  }
+
+  /**
+  * Builds the internal data for a component and adds
+  * an internal id to the component if necessary.
+  *
+  * @param {Component} component
+  */
+
+  function registerComponent (component) {
+    if (!component[internalId]) idComponent(component)
+    componentData[component[internalId]] = {
+      entities: {},
+      sources: []
+    }
+    registerSources(component)
+  }
+
+  /**
    * Register an entity.
    *
    * This is mostly to pre-preprocess component properties and values chains.
@@ -1041,13 +1119,9 @@ function render (app, container, opts) {
    */
 
   function register (entity) {
-    registerEntity(entity)
     var component = entity.component
-    if (component.registered) return
-
-    // initialize sources once for a component type.
-    registerSources(entity)
-    component.registered = true
+    if (!isRegistered(component)) registerComponent(component)
+    registerEntity(entity)
   }
 
   /**
@@ -1059,7 +1133,7 @@ function render (app, container, opts) {
   function registerEntity(entity) {
     var component = entity.component
     // all entities for this component type.
-    var entities = component.entities = component.entities || {}
+    var entities = getComponentEntities(component)
     // add entity to component list
     entities[entity.id] = entity
     // map to component so you can remove later.
@@ -1072,17 +1146,13 @@ function render (app, container, opts) {
    * @param {Entity} entity
    */
 
-  function registerSources(entity) {
-    var component = components[entity.id]
+  function registerSources(component) {
     // get 'class-level' sources.
-    // if we've already hooked it up, then we're good.
-    var sources = component.sources
-    if (sources) return
-    var entities = component.entities
+    var sources = getComponentSources(component)
+    var entities = getComponentEntities(component)
 
     // hook up sources.
     var map = component.sourceToPropertyName = {}
-    component.sources = sources = []
     var propTypes = component.propTypes
     for (var name in propTypes) {
       var data = propTypes[name]
@@ -1118,7 +1188,7 @@ function render (app, container, opts) {
   function setSources (entity) {
     var component = entity.component
     var map = component.sourceToPropertyName
-    var sources = component.sources
+    var sources = getComponentSources(component)
     sources.forEach(function (source) {
       var name = map[source]
       if (entity.pendingProps[name] != null) return

--- a/test/dom/index.js
+++ b/test/dom/index.js
@@ -1324,3 +1324,26 @@ test('should handle two-way updating with multiple components depending on the s
   teardown({renderer,el})
   end()
 })
+
+test('running multiple apps at once', ({equal,end}) => {
+  var app1 = setup(equal);
+  var app2 = setup(equal);
+
+  var Punc = {
+    render: ({props}) => <span>{props.punc}</span>
+  }
+
+  var Test = {
+    render: ({props}) => <span>{props.text}<Punc {...props} /></span>
+  }
+
+  app1.mount(<Test text="Hello" punc="," />)
+  app2.mount(<Test text="World" punc="!" />)
+
+  equal(app1.el.firstElementChild.innerText, 'Hello,', 'first app rendered correctly')
+  equal(app2.el.firstElementChild.innerText, 'World!', 'second app rendered correctly')
+
+  teardown({ renderer: app1.renderer, el: app1.el })
+  teardown({ renderer: app2.renderer, el: app2.el })
+  end()
+})

--- a/test/dom/index.js
+++ b/test/dom/index.js
@@ -1340,8 +1340,8 @@ test('running multiple apps at once', ({equal,end}) => {
   app1.mount(<Test text="Hello" punc="," />)
   app2.mount(<Test text="World" punc="!" />)
 
-  equal(app1.el.firstElementChild.innerText, 'Hello,', 'first app rendered correctly')
-  equal(app2.el.firstElementChild.innerText, 'World!', 'second app rendered correctly')
+  equal(app1.el.firstElementChild.textContent, 'Hello,', 'first app rendered correctly')
+  equal(app2.el.firstElementChild.textContent, 'World!', 'second app rendered correctly')
 
   teardown({ renderer: app1.renderer, el: app1.el })
   teardown({ renderer: app2.renderer, el: app2.el })


### PR DESCRIPTION
> Fixes #222. Storing internal component data on component definitions caused problems when running multiple apps simultaneously.

Made a number of changes here, the biggest being adding a concept of registering a component and adding an internal id to it so that we can store internal data on it. 

Looking at unit tests, the existing ones seem to test output while all of the changes here are for internal things, so I didn't add any. Please let me know if any of these internal things should be tested.

Also I'm unsure the best way to ensure that nothing broke. All unit tests pass but that's about all the assurance I've got.