### PR TITLE
only adjust text selection for the active element

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -1283,14 +1283,14 @@ function getRootElement (el) {
  */
 
 function setElementValue (el, value) {
-  if (!canSelectText(el)) {
+  if (el === document.activeElement && canSelectText(el)) {
+    var start = el.selectionStart
+    var end = el.selectionEnd
     el.value = value
-    return
+    el.setSelectionRange(start, end)
+  } else {
+    el.value = value
   }
-  var start = el.selectionStart
-  var end = el.selectionEnd
-  el.value = value
-  el.setSelectionRange(start, end)
 }
 
 /**

--- a/test/dom/index.js
+++ b/test/dom/index.js
@@ -208,7 +208,7 @@ test('innerHTML attribute', ({equal,end}) => {
   end()
 })
 
-test('input attributes', ({equal,end,ok,test,comment}) => {
+test('input attributes', ({equal,notEqual,end,ok,test,comment}) => {
   var {html,mount,el,renderer,$} = setup(equal)
   mount(<input />)
   var checkbox = $('input')
@@ -237,10 +237,11 @@ test('input attributes', ({equal,end,ok,test,comment}) => {
   mount(<input type="text" value="Hello World" />)
   var input = $('input')
   input.setSelectionRange(5,7)
-  input.blur()
+  if (input.setActive) document.body.setActive()
+  else input.blur()
   mount(<input type="text" value="Hello World!" />)
-  equal(input.selectionStart, 12, 'selection start')
-  equal(input.selectionEnd, 12, 'selection end')
+  notEqual(input.selectionStart, 5, 'selection start')
+  notEqual(input.selectionEnd, 7, 'selection end')
 
   comment('input.checked')
   mount(<input checked={true} />)

--- a/test/dom/index.js
+++ b/test/dom/index.js
@@ -224,6 +224,7 @@ test('input attributes', ({equal,end,ok,test,comment}) => {
   comment('input cursor position')
   mount(<input type="text" value="Game of Thrones" />)
   var input = $('input')
+  input.focus()
   input.setSelectionRange(5,7)
   mount(<input type="text" value="Way of Kings" />)
   equal(input.selectionStart, 5, 'selection start')
@@ -231,6 +232,15 @@ test('input attributes', ({equal,end,ok,test,comment}) => {
 
   comment('input cursor position on inputs that don\'t support text selection')
   mount(<input type="email" value="a@b.com" />)
+
+  comment('input cursor position only the active element')
+  mount(<input type="text" value="Hello World" />)
+  var input = $('input')
+  input.setSelectionRange(5,7)
+  input.blur()
+  mount(<input type="text" value="Hello World!" />)
+  equal(input.selectionStart, 12, 'selection start')
+  equal(input.selectionEnd, 12, 'selection end')
 
   comment('input.checked')
   mount(<input checked={true} />)


### PR DESCRIPTION
Calling `el.setSelectionRange()` should only happen when the element in question already has focus. A test has been added (and another updated) to account for this change. :)

/cc @anthonyshort 