### PR TITLE
fixing stringify for components with children

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -19,10 +19,11 @@ module.exports = function (app) {
    * @return {String}
    */
 
-  function stringify (component, optProps) {
+  function stringify (component, optProps, children) {
     var propTypes = component.propTypes || {}
     var props = defaults(optProps || {}, component.defaultProps || {})
     var state = component.initialState ? component.initialState(props) : {}
+    props.children = children;
 
     for (var name in propTypes) {
       var options = propTypes[name]
@@ -67,7 +68,7 @@ module.exports = function (app) {
 
         str += '</' + tagName + '>'
         return str
-      case 'component': return stringify(node.type, node.attributes)
+      case 'component': return stringify(node.type, node.attributes, node.children)
     }
 
     throw new Error('Invalid type')

--- a/test/string/index.js
+++ b/test/string/index.js
@@ -30,6 +30,17 @@ test('rendering virtual element to a string', ({equal,end}) => {
   end()
 })
 
+test('rendering components with children', ({equal,notEqual,end}) => {
+  var Component = {
+    render: function ({ props, state }) {
+      return <div>{props.children}</div>;
+    }
+  }
+  notEqual(render(<Component />), '<div>undefined</div>');
+  equal(render(<Component>test</Component>), '<div>test</div>');
+  end()
+})
+
 test('renderString: components', ({equal,end}) => {
   var Component = {
     defaultProps: {
@@ -59,7 +70,7 @@ test('renderString: lifecycle hooks', assert => {
       assert.ok(props, 'beforeRender has props')
       assert.ok(state, 'beforeRender has state')
     },
-    render: function(props, state){
+    render: function({ props, state }){
       return <div />
     }
   }


### PR DESCRIPTION
In deku 0.5, the string renderer discarded the children when rendering a component. (causing `undefined` to usually show up in place)

This fixes that bug and adds a test to prevent regression.

/cc @anthonyshort 