### PR TITLE
properly handling empty attrs, with tests to prevent regression

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -118,5 +118,15 @@ function attr (key, val) {
 
 function isValidAttributeValue (value) {
   var valueType = type(value)
-  return (valueType === 'string' || valueType === 'boolean' || valueType === 'number')
+  switch (valueType) {
+  case 'string':
+  case 'number':
+    return true;
+
+  case 'boolean':
+    return value;
+
+  default:
+    return false;
+  }
 }

--- a/test/string/index.js
+++ b/test/string/index.js
@@ -103,6 +103,26 @@ test('renderString: function attributes', assert => {
   assert.end()
 })
 
+test('renderString: empty attributes', assert => {
+  var app = deku(<input type="checkbox" value="" />)
+  assert.equal(renderString(app), '<input type="checkbox" value=""></input>', 'empty string attribute not rendered')
+
+  var app = deku(<input type="checkbox" value={0} />)
+  assert.equal(renderString(app), '<input type="checkbox" value="0"></input>', 'zero attribute not rendered')
+
+  var app = deku(<input type="checkbox" disabled={false} />)
+  assert.equal(renderString(app), '<input type="checkbox"></input>', 'false attribute unexpectedly rendered')
+
+  var app = deku(<input type="checkbox" disabled={null} />)
+  assert.equal(renderString(app), '<input type="checkbox"></input>', 'null attribute unexpectedly rendered')
+
+  var disabled;
+  var app = deku(<input type="checkbox" disabled={disabled} />)
+  assert.equal(renderString(app), '<input type="checkbox"></input>', 'undefined attribute unexpectedly rendered')
+
+  assert.end()
+})
+
 test('rendering data sources to a string', ({equal,end}) => {
   var Component = {
     propTypes: {


### PR DESCRIPTION
some "empty" attributes were being rendered incorrectly by the string renderer. (such as `false` becoming a `"false"` attribute)

This adds tests for all sorts of empty values, and they are all passing.