### PR TITLE
Add failing test for input values

### DIFF
--- a/test/dom/index.js
+++ b/test/dom/index.js
@@ -218,6 +218,8 @@ test('input attributes', ({equal,notEqual,end,ok,test,comment}) => {
   equal(checkbox.value, 'Bob', 'value property set')
   mount(<input value="Tom" />)
   equal(checkbox.value, 'Tom', 'value property updated')
+  mount(<input value={0} />)
+  equal(checkbox.value, '0', 'value property updated')
   mount(<input />)
   equal(checkbox.value, '', 'value property removed')
 


### PR DESCRIPTION
Expected value is `'0'` and actual `''`.

See #253 for reference.