### PR TITLE
Don't treat number as a falsy attribute

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -839,7 +839,7 @@ function render (app, container, opts) {
    */
 
   function setAttribute (entityId, path, el, name, value) {
-    if (!value) {
+    if (!value && typeof value !== 'number') {
       removeAttribute(entityId, path, el, name)
       return
     }


### PR DESCRIPTION
A value of `0` was treated as a falsy value.

Test passes in #254.