### PR TITLE
modify jsx instructions to show babel 5 + 6 variations

### DIFF
--- a/docs/guides/jsx.md
+++ b/docs/guides/jsx.md
@@ -18,15 +18,31 @@ export function render (component) {
 }
 ```
 
-There are a number of libraries around now that can transpile JSX into JS that aren't tied to React. The easiest way to use JSX with Deku is to use [Babel](https://github.com/babel/babel). 
+There are a number of libraries around now that can transpile JSX into JS that aren't tied to React. The easiest way to use JSX with Deku is to use [Babel](https://github.com/babel/babel).
 
 ## .babelrc
 
 The easiest way is to add it to your `.babelrc` file:
 
+In Babel 5,
+
 ```
 {
   "jsxPragma": "element"
+}
+```
+
+However, in Babel 6, everything was modularized so you'll need to run
+
+`npm install babel-plugin-transform-react-jsx`
+
+and include the plugin in your `.babelrc` file-
+
+```
+{
+  "plugins": [
+    ["transform-react-jsx", { "pragma": "element" }]
+  ]
 }
 ```
 


### PR DESCRIPTION
was setting up a deku project w/ babel 6 and noticed a bunch of stuff changed :P

though babel 6 is now stable, i left babel 5 instructions in since it's quite popular, but let me know if you'd like to just leave babel 6 in and i'll update the pr