### PR TITLE
JSX instructions for Babel v6

### DIFF
--- a/docs/guides/jsx.md
+++ b/docs/guides/jsx.md
@@ -18,17 +18,25 @@ export function render (component) {
 }
 ```
 
-There are a number of libraries around now that can transpile JSX into JS that aren't tied to React. The easiest way to use JSX with Deku is to use [Babel](https://github.com/babel/babel). 
+There are a number of libraries around now that can transpile JSX into JS that aren't tied to React. The easiest way to use JSX with Deku is to use [Babel](https://github.com/babel/babel).
 
 ## .babelrc
 
-The easiest way is to add it to your `.babelrc` file:
+The easiest way is to install Babel's [React JSX Transform plugin](http://babeljs.io/docs/plugins/transform-react-jsx/):
+
+`npm install babel-plugin-transform-react-jsx`
+
+and then, include it via your `.babelrc` file:
 
 ```
 {
-  "jsxPragma": "element"
+  "plugins": [
+    ["transform-react-jsx", { "pragma": "element" }]
+  ]
 }
 ```
+
+See [here](https://github.com/dekujs/deku/blob/b4ebc98eb8eb295c59f0aa07bea2a8c3257ad827/docs/guides/jsx.md#babelrc) for Babel 5 instructions.
 
 Then make sure you import the `element` function:
 


### PR DESCRIPTION
preferred to my old pr, #279, to reduce clutter in the docs

- adds babel 6 instructions
- points back to babel 5 instructions (since it's still popular)