### PR TITLE
Fixed bug with adding events

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -1158,9 +1158,9 @@ function render (app, container, opts) {
     keypath.set(handlers, [entityId, path, eventType], function (e) {
       var entity = entities[entityId]
       if (entity) {
-        return addEvent(null, e, entity.context, setState(entity))
+        return fn(e, entity.context, setState(entity))
       } else {
-        return addEvent(null, e)
+        return fn(e)
       }
     })
   }


### PR DESCRIPTION
The addEvent method was broken in 45d7a7f. This more or less reverts that change. I've also replaced `fn.call(null,` with `fn(` since using `call` isn't necessary. Standard linting throws an error for this.