### PR TITLE
Reduce build file size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,14 @@ $(tests): node_modules
 standalone: $(src)
 	@mkdir -p build
 	@NODE_ENV=production browserify \
+		--insert-global-vars __filename,__dirname,process,global \
 		--standalone deku \
 		-t envify \
 		-e lib/index.js | bfc > build/deku.js
 
 test: $(src) $(tests)
 	@NODE_ENV=development hihat test/index.js -- \
+		--insert-global-vars __filename,__dirname,process,global \
 		--debug \
 		-t envify \
 		-t babelify \


### PR DESCRIPTION
Curently, The file size of [build/deku.js](https://github.com/dekujs/deku/blob/master/build/deku.js "build/deku.js") is 112KB.

This pull request reduce the file size - 112KB => 62KB.

Analyzed `build/deku.js` by [disc](https://github.com/hughsk/disc "disc").

![disk](https://i.gyazo.com/18abb122b8803e9343adb4a35c78a882.gif)

It is caused mainly by `Buffer` shim.

If browserify detects the use of `Buffer`, it will include a browser-appropriate definition.
This behavior is defined in `--insert-global-vars` option.
Default: `__filename,__dirname,process,Buffer,global`
This commit remove `Buffer` from `--insert-global-vars` option values.

[component-type](https://www.npmjs.com/package/component-type "component-type") actually reference `Buffer`, but it is not dependent on `Buffer`.

https://github.com/component/type/blob/master/index.js

```js
  if (typeof Buffer != 'undefined' && Buffer.isBuffer(val)) return 'buffer';
```

References: 

https://github.com/substack/node-browserify#usage
https://github.com/substack/browserify-handbook#builtins