### PR TITLE
Iteration example: fix className attribute

### DIFF
--- a/docs/examples/iteration/index.js
+++ b/docs/examples/iteration/index.js
@@ -71,7 +71,7 @@ let List = {
 
     return (
       <div>
-        <ul className="listItems">
+        <ul class="listItems">
           { items }
         </ul>
         <input type="text"/>


### PR DESCRIPTION
deku supports `class`, no need for `className`