### PR TITLE
Add missing `arrow` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ let render = dom.createRenderer(document.body, store.dispatch)
 
 // Define a state-less component
 let MyButton = {
-  render: ({ props, children }) {
+  render: ({ props, children }) => {
     return <button class="my-button">{children}</button>
   }
 }

--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -8,7 +8,7 @@ let {createRenderer} = dom
 let render = createRenderer(document.body)
 
 let MyButton = {
-  render: ({ children }) {
+  render: ({ children }) => {
     return <button class="my-button">{children}</button>
   }
 }


### PR DESCRIPTION
If I'm not mistaken arrows is missing in those functions.