### PR TITLE
Docs: improve JSX documentation

### DIFF
--- a/docs/basics/JSX.md
+++ b/docs/basics/JSX.md
@@ -1,12 +1,22 @@
 # JSX
 
-The `element` function used to create virtual elements is compatible with [JSX](http://jsx.github.io) through [Babel](https://babeljs.io). When using Babel you just need to set the `jsxPragma`. This allows you to automatically transform HTML in your code into `element` calls.
+The `element` function used to create virtual elements is compatible with [JSX] through [Babel]. When using Babel you just need to set the `jsxPragma`. This allows you to automatically transform HTML in your code into `element` calls.
 
-## Setting the pragma
+[JSX]: https://facebook.github.io/jsx/
+[Babel]: https://babeljs.io
 
-Here's an example `.babelrc` that sets the pragma:
+## Setting up Babel
+
+Be sure to install [babel-preset-es2015](http://babeljs.io/docs/plugins/preset-es2015/) and [babel-plugin-transform-react-jsx](https://babeljs.io/docs/plugins/transform-react-jsx/).
 
 ```
+npm install babel-preset-es2015
+npm install babel-plugin-transform-react-jsx
+```
+
+You will need to set the `pragma`. Here's an example `.babelrc` that sets the pragma:
+
+```json
 {
   "presets": ["es2015"],
   "plugins": [
@@ -14,6 +24,30 @@ Here's an example `.babelrc` that sets the pragma:
   ]
 }
 ```
+
+Alternatively, you can specify it in each of your files with a `@jsx` pragma comment:
+
+```js
+/** @jsx element */
+
+import { element } from 'deku'
+```
+
+From here, you can use [browserify] with [babelify] to build your final .js package.
+
+```sh
+npm install --save browserify
+npm install --save babelify
+
+# compile the entry point `index.js` to `dist/application.js`
+browserify -t babelify index.js -o dist/application.js
+```
+
+Alternatively, you can also use [babel-cli] to compile your JS files.
+
+[browserify]: https://www.npmjs.com/package/browserify
+[babelify]: https://www.npmjs.com/package/babelify
+[babel-cli]: https://www.npmjs.com/package/babel-cli
 
 ## How does it work?
 


### PR DESCRIPTION
- "JSX" was linking to the wrong project.
- Added a note about browserify + babelify.
- Added `npm install` commands.
- Added a note about `/** @jsx */` pragma comments.