### PR TITLE
Fix context disappearing across re-renders

### DIFF
--- a/src/dom/patch.js
+++ b/src/dom/patch.js
@@ -32,7 +32,7 @@ export default function patch (dispatch, context) {
               insertAtIndex(
                 DOMElement,
                 index,
-                createElement(vnode, path, dispatch)
+                createElement(vnode, path, dispatch, context)
               )
             },
             removeChild: (index) => {

--- a/test/createDOMRenderer.js
+++ b/test/createDOMRenderer.js
@@ -147,3 +147,25 @@ test('rendering the same node', t => {
   )
   t.end()
 })
+
+test('context should be passed down across re-renders even after disappearance', t => {
+  let Form = {
+    render ({ props }) {
+      return <div>{ props.visible ? <Button /> : [] }</div>
+    }
+  }
+  let Button = {
+    render ({ props, context }) {
+      t.equal(context, 'the context', 'context is passed down')
+      return <button>Submit</button>
+    }
+  }
+  let el = document.createElement('div')
+  let render = createDOMRenderer(el)
+  t.plan(2)
+  render(<Form visible={true} />, 'the context')
+  render(<Form visible={false} />, 'the context')
+  render(<Form visible={true} />, 'the context')
+  t.end()
+})
+

--- a/test/createDOMRenderer.js
+++ b/test/createDOMRenderer.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/prop-types */
+
 /** @jsx h */
 import test from 'tape'
 import createDOMRenderer from '../src/dom/createRenderer'
@@ -163,9 +165,9 @@ test('context should be passed down across re-renders even after disappearance',
   let el = document.createElement('div')
   let render = createDOMRenderer(el)
   t.plan(2)
-  render(<Form visible={true} />, 'the context')
-  render(<Form visible={false} />, 'the context')
-  render(<Form visible={true} />, 'the context')
+  render(<Form visible />, 'the context')
+  render(<Form />, 'the context')
+  render(<Form visible />, 'the context')
   t.end()
 })
 


### PR DESCRIPTION
Found another case where `context` can disappear.

```js
  let Form = {
    render ({ props }) {
      return <div>{ props.visible ? <Button /> : [] }</div>
    }
  }

  let Button = {
    render ({ props, context }) {
      t.equal(context, 'the context', 'context is passed down')    💣💣💣
      return <button>Submit</button>
    }
  }

  let el = document.createElement('div')
  let render = createDOMRenderer(el)

  render(<Form visible={true} />, 'the context')
  render(<Form visible={false} />, 'the context')
  render(<Form visible={true} />, 'the context')
})
```

v2.0.0-rc6 makes context disappear on the 3rd `render()`. This fixes that.