### PR TITLE
Add test for elements with attributes after a null element

### DIFF
--- a/test/createDOMRenderer.js
+++ b/test/createDOMRenderer.js
@@ -133,3 +133,24 @@ test('rendering numbers as text elements', t => {
   )
   t.end()
 })
+
+test.skip('setting attribute after a null node', t => {
+  let el = document.createElement('div')
+  let render = createDOMRenderer(el)
+  let Component = {
+    render ({ props }) {
+      return <div>
+        { props.heading ? <h2>Image</h2> : null }
+        <span style={props.style}></span>
+      </div>
+    }
+  }
+  render(<Component style='color: blue' />)
+  render(<Component />)
+  t.equal(
+    el.innerHTML,
+    '<div><span></span></div>',
+    'rendered correctly'
+  )
+  t.end()
+})


### PR DESCRIPTION
Here's another case that I see that fails:

```js
  let Component = {
    render ({ props }) {
      return <div>
        { null }
        <span style={props.style}></span>
      </div>
    }
  }
  render(<Component style='color: blue' />)
  render(<Component />)
```

> Uncaught TypeError: Cannot read property 'removeAttribute' of undefined

I've added a failing test for this.