### PR TITLE
Handle the sameNode action (#333)

### DIFF
--- a/src/dom/patch.js
+++ b/src/dom/patch.js
@@ -20,6 +20,7 @@ export default function patch (dispatch, context) {
       insertBefore: (index) => {
         insertAtIndex(DOMElement.parentNode, index, DOMElement)
       },
+      sameNode: () => {},
       updateChildren: (changes) => {
         // Create a clone of the children so we can reference them later
         // using their original position even if they move around

--- a/test/createDOMRenderer.js
+++ b/test/createDOMRenderer.js
@@ -133,3 +133,17 @@ test('rendering numbers as text elements', t => {
   )
   t.end()
 })
+
+test('rendering the same node', t => {
+  let el = document.createElement('div')
+  let render = createDOMRenderer(el)
+  var node = <div></div>
+  render(node)
+  render(node)
+  t.equal(
+    el.innerHTML,
+    '<div></div>',
+    'samenode is handled'
+  )
+  t.end()
+})


### PR DESCRIPTION
Fixes #333.

```js
test('rendering the same node', t => {
  let el = document.createElement('div')
  let render = createDOMRenderer(el)
  var node = <div></div>
  render(node)
  render(node)
  t.equal(
    el.innerHTML,
    '<div></div>',
    'samenode is handled'
  )
  t.end()
})
```