### PR TITLE
Remove unneeded condition.

### DIFF
--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -8,7 +8,6 @@ export function isValidAttribute (value) {
   if (value === '') return true
   if (value === undefined) return false
   if (value === null) return false
-  if (value === false) return false
   return true
 }
 


### PR DESCRIPTION
The first condition already handles booleans.