### PR TITLE
Enabling plain functions as components

### DIFF
--- a/src/element/index.js
+++ b/src/element/index.js
@@ -27,6 +27,10 @@ export default function element (type, attributes, ...children) {
     return createThunkElement(type, key, attributes, children)
   }
 
+  if (typeof type === 'function') {
+    return createThunkElement({render: type, ...type}, key, attributes, children);
+  }
+
   return {
     attributes,
     children,

--- a/test/createElement.js
+++ b/test/createElement.js
@@ -75,3 +75,11 @@ test('create element with thunk', t => {
   t.equal(DOMElement.tagName, 'DIV', 'is correct tag')
   t.end()
 })
+
+test('crate element with plain function thunk', t => {
+  let Component = () => <div />
+  let DOMElement = createElement(<Component />)
+  t.assert(isDOM(DOMElement), 'is DOM element')
+  t.equal(DOMElement.tagName, 'DIV', 'is correct tag')
+  t.end()
+})


### PR DESCRIPTION
Just a proposition to add plain function as components. I know that you might have dropped it because it seems to exist in the Quick Start section but is actually not implemented.

Related to dekujs/deku#350.
