### PR TITLE
Don't treat `0` as a falsy value 

### DIFF
--- a/src/dom/createElement.js
+++ b/src/dom/createElement.js
@@ -11,7 +11,10 @@ const cache = {}
 
 export default function createElement (vnode, path, dispatch, context) {
   if (isText(vnode)) {
-    return document.createTextNode(vnode.nodeValue || '')
+    let value = typeof vnode.nodeValue === 'string' || typeof vnode.nodeValue === 'number'
+      ? vnode.nodeValue
+      : ''
+    return document.createTextNode(value)
   }
 
   if (isThunk(vnode)) {

--- a/test/createDOMRenderer.js
+++ b/test/createDOMRenderer.js
@@ -136,6 +136,18 @@ test('rendering numbers as text elements', t => {
   t.end()
 })
 
+test('rendering zero as text element', t => {
+  let el = document.createElement('div')
+  let render = createDOMRenderer(el)
+  render(<span>{0}</span>)
+  t.equal(
+    el.innerHTML,
+    '<span>0</span>',
+    'zero rendered correctly'
+  )
+  t.end()
+})
+
 test('rendering the same node', t => {
   let el = document.createElement('div')
   let render = createDOMRenderer(el)


### PR DESCRIPTION
Is there any better way to check for falsy values except numbers?

Fixes #354.