### PR TITLE
Fixing an issue concerning string children passed to the element function

### DIFF
--- a/src/element/index.js
+++ b/src/element/index.js
@@ -39,15 +39,16 @@ export default function element (type, attributes, ...children) {
   }
 }
 
-function reduceChildren (children, vnode) {
-  if (typeof vnode === 'string' || typeof vnode === 'number') {
-    children.push(createTextElement(vnode))
-  } else if (Array.isArray(vnode)) {
-    children = [...children, ...vnode]
-  } else if (typeof vnode !== 'undefined') {
-    children.push(vnode)
-  }
-  return children
+function reduceChildren (children, vnodes) {
+  let newChildren =  [].concat(vnodes).map(n => {
+    if (typeof n === 'string' || typeof n === 'number')
+      return createTextElement(n);
+    return n;
+  })
+
+  children.push.apply(children, newChildren);
+
+  return children;
 }
 
 export function createTextElement (text) {

--- a/test/element.js
+++ b/test/element.js
@@ -1,0 +1,78 @@
+/** @jsx h */
+import test from 'tape'
+import h from '../src/element'
+
+test('element', t => {
+  let vnode = h('div')
+
+  t.deepEqual(vnode, {
+    attributes: {},
+    children: [],
+    key: undefined,
+    type: 'div'
+  })
+
+  t.end()
+})
+
+test('element with attributes', t => {
+  let vnode = h('div', {name: 'John'})
+
+  t.deepEqual(vnode, {
+    attributes: {name: 'John'},
+    children: [],
+    key: undefined,
+    type: 'div'
+  })
+
+  t.end()
+})
+
+test('element with attributes and key', t => {
+  let vnode = h('div', {name: 'John', key: '$key$'})
+
+  t.deepEqual(vnode, {
+    attributes: {name: 'John'},
+    children: [],
+    key: '$key$',
+    type: 'div'
+  })
+
+  t.end()
+})
+
+test('element with single string child', t => {
+  let vnode = h('div', null, 'test')
+
+  t.deepEqual(vnode, {
+    attributes: {},
+    children: [
+      {
+        nodeValue: 'test',
+        type: '#text'
+      }
+    ],
+    key: undefined,
+    type: 'div'
+  })
+
+  t.end()
+})
+
+test('element with array containing string child', t => {
+  let vnode = h('div', null, ['test'])
+
+  t.deepEqual(vnode, {
+    attributes: {},
+    children: [
+      {
+        nodeValue: 'test',
+        type: '#text'
+      }
+    ],
+    key: undefined,
+    type: 'div'
+  })
+
+  t.end()
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 import 'babel-polyfill'
 import './groupByKey'
 import './setAttribute'
+import './element'
 import './createElement'
 import './patch'
 import './diffAttributes'


### PR DESCRIPTION
Deku fails if someone passes strings/numbers into the children array:

```js
// does not work as of 2.0.0-rc8
element('div', null, ['test'])
```

This PR fixes the problem and adds some tests (not exhaustive) to the `element` function.