### PR TITLE
Fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - "5"
 script:
   - npm run test:lint
-  - if [ -n "$TRAVIS_TAG" ]; then npm run test:browsers; else npm run test:headless; fi
+  - npm run test:headless

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - "5"
 script:
   - npm run test:lint
-  - npm run test:ci
+  - if [ -n "$TRAVIS_TAG" ]; then npm run test:browsers; else npm run test:headless; fi

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "clean": "rimraf lib _book",
     "build": "babel src --out-dir lib",
     "test": "hihat test/index.js -- --debug -t babelify -p tap-dev-tool",
-    "test:ci": "zuul -- ./test/index.js",
+    "test:headless": "browserify test/index.js -t babelify | tape-run",
+    "test:browsers": "zuul -- ./test/index.js",
     "test:lint": "standard src/*.js test/*.js | snazzy",
     "docs:install": "gitbook install",
     "docs:build": "npm run docs:install && gitbook build",
@@ -40,6 +41,7 @@
     "standard": "^5.4.1",
     "tap-dev-tool": "^1.3.0",
     "tape": "^4.2.2",
+    "tape-run": "^2.1.0",
     "trigger-event": "^1.0.0",
     "zuul": "^3.7.1"
   },


### PR DESCRIPTION
The tests breaking all the time makes it really hard to just quickly accept useful PRs. This runs tests using tape-run instead of zuul. We can manually run the browser tests when needed.