### PR TITLE
fixed build:lint globs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 _book
 dist
 lib
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "hihat test/index.js -- --debug -t babelify -p tap-dev-tool",
     "test:headless": "browserify test/index.js -t babelify | tape-run",
     "test:browsers": "zuul -- ./test/index.js",
-    "test:lint": "standard src/*.js test/*.js | snazzy",
+    "test:lint": "standard src/**/*.js test/**/*.js | snazzy",
     "docs:install": "gitbook install",
     "docs:build": "npm run docs:install && gitbook build",
     "docs:serve": "npm run docs:install && gitbook serve",

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -22,14 +22,14 @@ export function create (container, dispatch, options = {}) {
 
   let create = (vnode, context) => {
     node = dom.create(vnode, rootId, dispatch, context)
-    if (container){
-      if(container.childNodes.length === 0){
+    if (container) {
+      if (container.childNodes.length === 0) {
         container.appendChild(node)
-      }else{
-        if (container.attributes.checksum){
+      } else {
+        if (container.attributes.checksum) {
           let preRendered = adler32(container.innerHTML)
           let toBeRendered = adler32(node.outerHTML)
-          if(preRendered != toBeRendered){
+          if (preRendered !== toBeRendered) {
             container.innerHTML = ''
             container.appendChild(node)
           }

--- a/test/app/index.js
+++ b/test/app/index.js
@@ -286,7 +286,7 @@ test('rendering in a container with pre-rendered HTML', t => {
 
   el.innerHTML = '<div><span id="1"></span><span id="2"></span></div>'
   let render = createDOMRenderer(el)
-  render(<div><span id="2"></span></div>)
+  render(<div><span id='2'></span></div>)
   t.equal(
     el.innerHTML,
     '<div><span id="1"></span><span id="2"></span></div>',


### PR DESCRIPTION
The npm build:lint globs weren't recursive, so standard was only checking the top level folder in `src` and `test`. I fixed this and fixed the lint while I was at it.